### PR TITLE
NAB-628 NablarchLogger#isEnabledForLevelを実装し、isErrorEnabled等と同等にする

### DIFF
--- a/src/main/java/nablarch/core/log/NablarchLogger.java
+++ b/src/main/java/nablarch/core/log/NablarchLogger.java
@@ -1,5 +1,6 @@
 package nablarch.core.log;
 
+import org.slf4j.event.Level;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MarkerIgnoringBase;
 import org.slf4j.helpers.MessageFormatter;
@@ -24,6 +25,17 @@ public class NablarchLogger extends MarkerIgnoringBase {
 	 */
 	public NablarchLogger(final Logger logger) {
 		this.logger = logger;
+	}
+
+	@Override
+	public boolean isEnabledForLevel(Level level) {
+		return switch (level) {
+			case ERROR -> isErrorEnabled();
+			case WARN -> isWarnEnabled();
+			case INFO -> isInfoEnabled();
+			case DEBUG -> isDebugEnabled();
+			case TRACE -> isTraceEnabled();
+		};
 	}
 
 	@Override

--- a/src/test/java/nablarch/core/log/NablarchLoggerTest.java
+++ b/src/test/java/nablarch/core/log/NablarchLoggerTest.java
@@ -102,6 +102,28 @@ public class NablarchLoggerTest {
 					"debug | false",
 					"trace | true");
 		}
+
+		private void isEnabledForLevelTest(Level level, IsEnabled expected){
+			IsEnabled invoker = logger -> logger.isEnabledForLevel(level);
+			final org.slf4j.Logger testLogger = LoggerFactory.getLogger(level.toString());
+
+			assertEquals(invoker.test(testLogger), expected.test(testLogger));
+		}
+
+		@Test
+		public void isEnabledForLevelError() { isEnabledForLevelTest(Level.ERROR, Logger::isErrorEnabled); }
+
+		@Test
+		public void isEnabledForLevelWarn() { isEnabledForLevelTest(Level.WARN, Logger::isWarnEnabled); }
+
+		@Test
+		public void isEnabledForLevelInfo() { isEnabledForLevelTest(Level.INFO, Logger::isInfoEnabled);	}
+
+		@Test
+		public void isEnabledForLevelDebug() { isEnabledForLevelTest(Level.DEBUG, Logger::isDebugEnabled); }
+
+		@Test
+		public void isEnabledForLevelTrace() { isEnabledForLevelTest(Level.TRACE, Logger::isTraceEnabled); }
 	}
 
 	public static abstract class Base {

--- a/src/test/java/nablarch/core/log/NablarchLoggerTest.java
+++ b/src/test/java/nablarch/core/log/NablarchLoggerTest.java
@@ -8,9 +8,11 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -37,25 +39,18 @@ public class NablarchLoggerTest {
 			}
 		}
 
-		interface IsEnabled {
-			boolean invoke(org.slf4j.Logger logger);
-		}
+		interface IsEnabled extends Predicate<Logger> {}
 
 		private void isEnabledTest(IsEnabled invoker, String... parameters) {
 			for (IsEnabledTestParameter parameter : IsEnabledTestParameter.of(parameters)) {
 				final org.slf4j.Logger logger = LoggerFactory.getLogger(parameter.name);
-				assertEquals(parameter.expected, invoker.invoke(logger));
+				assertEquals(parameter.expected, invoker.test(logger));
 			}
 		}
 
 		@Test
 		public void isErrorEnabled() {
-			IsEnabled invoker = new IsEnabled() {
-				@Override
-				public boolean invoke(org.slf4j.Logger logger) {
-					return logger.isErrorEnabled();
-				}
-			};
+			IsEnabled invoker = Logger::isErrorEnabled;
 			isEnabledTest(invoker,
 					"error | true",
 					"warn  | true",
@@ -66,12 +61,7 @@ public class NablarchLoggerTest {
 
 		@Test
 		public void isWarnEnabled() {
-			IsEnabled invoker = new IsEnabled() {
-				@Override
-				public boolean invoke(org.slf4j.Logger logger) {
-					return logger.isWarnEnabled();
-				}
-			};
+			IsEnabled invoker = Logger::isWarnEnabled;
 			isEnabledTest(invoker,
 					"error | false",
 					"warn  | true",
@@ -82,12 +72,7 @@ public class NablarchLoggerTest {
 
 		@Test
 		public void isInfoEnabled() {
-			IsEnabled invoker = new IsEnabled() {
-				@Override
-				public boolean invoke(org.slf4j.Logger logger) {
-					return logger.isInfoEnabled();
-				}
-			};
+			IsEnabled invoker = Logger::isInfoEnabled;
 			isEnabledTest(invoker,
 					"error | false",
 					"warn  | false",
@@ -98,12 +83,7 @@ public class NablarchLoggerTest {
 
 		@Test
 		public void isDebugEnabled() {
-			IsEnabled invoker = new IsEnabled() {
-				@Override
-				public boolean invoke(org.slf4j.Logger logger) {
-					return logger.isDebugEnabled();
-				}
-			};
+			IsEnabled invoker = Logger::isDebugEnabled;
 			isEnabledTest(invoker,
 					"error | false",
 					"warn  | false",
@@ -114,12 +94,7 @@ public class NablarchLoggerTest {
 
 		@Test
 		public void isTraceEnabled() {
-			IsEnabled invoker = new IsEnabled() {
-				@Override
-				public boolean invoke(Logger logger) {
-					return logger.isTraceEnabled();
-				}
-			};
+			IsEnabled invoker = Logger::isTraceEnabled;
 			isEnabledTest(invoker,
 					"error | false",
 					"warn  | false",


### PR DESCRIPTION
- https://nablarch.atlassian.net/browse/NAB-628

## 概要

NablarchLogger#isEnabledForLevelを実装し、isErrorEnabled等と一貫性のある動作にする

## 変更による影響

なし(結果的に、当該の実装を行っても出力は変わらなかった)　詳細は下記テスト参照
https://github.com/nablarch/slf4j-nablarch-adaptor/pull/7/files#diff-b7225091fda96d6511f3c52a67ef58f9fd8d127051e1891626271e323a2783f7R106

